### PR TITLE
Add proxyfix for correct ips behind a reverse proxy

### DIFF
--- a/blobserver/app.py
+++ b/blobserver/app.py
@@ -3,6 +3,7 @@
 import flask
 from flask_cors import CORS
 import jinja2.utils
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 import blobserver.about
 import blobserver.config
@@ -27,6 +28,8 @@ utils.init(app)
 blobserver.user.init(app)
 blobserver.blob.init(app)
 
+if app.config["REVERSE_PROXY"]:
+    app.wsgi_app = ProxyFix(app.wsgi_app)
 
 @app.context_processor
 def setup_template_context():

--- a/blobserver/config.py
+++ b/blobserver/config.py
@@ -37,6 +37,7 @@ DEFAULT_SETTINGS = dict(
     ADMIN_USERNAME=None,        # Admin user to create at startup, if not exists.
     ADMIN_EMAIL=None,
     ADMIN_PASSWORD=None,
+    REVERSE_PROXY=False,
 )
 
 


### PR DESCRIPTION
Add `ProxyFix` to support getting correct IPs when behind a reverse proxy.

Add the setting `"REVERSE_PROXY": true` to `settings.json` to activate it.